### PR TITLE
Use https for bertha

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,11 +51,11 @@ You can create a new google spreadsheet quite easily, shared to be viewable by a
 
 The latest contents of the spreadsheet are exported to Bertha, via a similar url constructed from the spreadsheet's UUID and sheet name.
 
-* http://bertha.ig.ft.com/republish/publish/gss/UUID/SheetName
+* https://bertha.ig.ft.com/republish/publish/gss/UUID/SheetName
 
 Bertha then exposes a JSON feed of the spreadsheet's contents, accessible via a slightly different URL.
 
-* http://bertha.ig.ft.com/view/publish/gss/UUID/SheetName
+* https://bertha.ig.ft.com/view/publish/gss/UUID/SheetName
 
 The first row of the spreadsheet needs to name the following columns as a minimum:
 

--- a/client/js/main.js
+++ b/client/js/main.js
@@ -2,7 +2,7 @@
 
 const graph = require('./lib/d3');
 const extend = require('util')._extend;
-const berthaRoot = 'http://bertha.ig.ft.com/';
+const berthaRoot = 'https://bertha.ig.ft.com/';
 const berthaView = 'view/publish/gss/';
 const berthaRepublish = 'republish/publish/gss/';
 const {


### PR DESCRIPTION
You may link to the [scant docs](https://github.com/ft-interactive/bertha/wiki/Tutorial).

_A plea_: the Bertha docs need to be improved. Show thanks to the Bertha elves by helping to improve the docs.
