### PR TITLE
Small fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,11 +33,15 @@ The mandatory parameters point to a specific Google spreadsheet (that has been p
 Open the spreadsheet you want to display and copy the UID of the document. This will be the value for the `id` parameter.
 The `sheet` parameter is the name of the sheet in the spreadsheet document that contains the information you wish to display.
 
+An empty value (e.g. `&sortcol=&dashboard=&ringcolor=`) just fallback to the default value.
+
 The rest:
+
 
 Arrays are comma seperated values e.g. `param=item1,item2,item3`
 Strings are just single values e.g. `param=myString`
-Booleans are the value `false` or any other value, e.g. `&bool=false` is false; `&bool` or `&bool=true` are true,
+Booleans are the value `false` or any other value, e.g. `&bool=false` is false; `&bool=true` is true,
+Numbers are any positive real number. E.g. `&number=0.1`, `&number=50`
 
 * sortcol (String) - It will try to sort the column numerically and will do so if any of the items start with a number. Failing to find any numbers it will sort it alphabetically. The groups will be drawn on the graph.
 * showcol (Array) - Other columns to show as headers in the table, all other information can be revealed with a click.
@@ -52,6 +56,10 @@ Booleans are the value `false` or any other value, e.g. `&bool=false` is false; 
 ..* **special case: 'rainbow'**
 * proportionalrings (Boolean) - Whether to make the rings with more elements have more room.
 * sorttype (String) - 'alphabetical' or 'numerical', if sorted numerically items not beginning with a number will have a value of zero.
+* title (String) - Title on the Display
+* crystallisation (String) - Ring to highlight
+* noderepulsion (Number) - How strongly the nodes repel each other (default, 3)
+* nodeattraction (Number) - How strongly the nodes are pulled to the center of the segment (default, 3)
 
 Any of the above parameters can also be entered in the spreadsheet under name and configvalue columns e.g.
 

--- a/client/index.html
+++ b/client/index.html
@@ -57,11 +57,11 @@
 				</div>
 			</div>
 		</div>
-		<div class="o-grid-row">
-			<div id="tech-radar__filter-list-target" data-o-grid-colspan="12 S4">
-				<div id="boil-down"></div>
+		<div id="tech-radar__display">
+			<div id="boil-down"></div>
+			<div id="tech-radar__graph-target">
 			</div>
-			<div id="tech-radar__graph-target" data-o-grid-colspan="12 S8">
+			<div id="tech-radar__filter-list-target">
 			</div>
 		</div>
 	</div>

--- a/client/js/lib/d3.js
+++ b/client/js/lib/d3.js
@@ -99,8 +99,8 @@ module.exports = function ({
 			y,
 			weight,
 			text,
-			charge: -250,
-			chargeDistance: 90,
+			charge: -2500,
+			chargeDistance: totalRingSize/(rings.length),
 			id: nodeToAttachTo['hidden-graph-item-id'] + '--graph-label'
 		};
 
@@ -148,9 +148,9 @@ module.exports = function ({
 
 	const svgNode = document.createElementNS(d3.ns.prefix.svg, 'svg');
 	const svg = d3.select(svgNode)
-		.attr('width', width + 500)
-		.attr('height', height + 50)
-		.attr('viewBox', `-500 -50 ${width + 500} ${height + 50}`);
+		.attr('width', width + 500 + 50)
+		.attr('height', height + 100)
+		.attr('viewBox', `-500 -50 ${width + 500 + 50} ${height + 100}`);
 
 	const force = d3.layout.force()
 		.nodes(nodes)
@@ -169,7 +169,7 @@ module.exports = function ({
 		.chargeDistance(n => n.chargeDistance || 10)
 		.gravity(0)
 		.linkStrength(1)
-		.linkDistance(0.1)
+		.linkDistance(3)
 		.size([width, height]);
 
 	force.on('tick', function () {
@@ -274,7 +274,7 @@ module.exports = function ({
 	}
 
 	node.append('circle')
-		.attr('class', n => `node${n.dot === false ? ' no-dot' : ''}`)
+		.attr('class', n => `node${n.dot === false ? ' segment-label' : ''}`)
 		.attr('r', 8)
 		.style('fill', n => `hsla(${n['hidden-graph-item-hue']}, 95%, 60%, 1)`)
 		.on('mouseover', mouseover)
@@ -285,13 +285,13 @@ module.exports = function ({
 
 	node.append('svg:text')
 		.text(n => n.dot === false ? n.name : '')
-		.attr('class', 'd3-label bg no-dot')
+		.attr('class', 'd3-label bg segment-label')
 		.attr('x', '-10px')
 		.attr('y', '5px');
 
 	node.append('svg:text')
 		.text(n => n.dot === false ? n.name : '')
-		.attr('class', 'd3-label no-dot')
+		.attr('class', 'd3-label segment-label')
 		.attr('x', '-10px')
 		.attr('y', '5px');
 
@@ -299,15 +299,29 @@ module.exports = function ({
 
 	rings.reverse();
 	for (const ring of rings) {
-		rootNode.append('circle')
+		rootNode.append('svg:circle')
 			.attr('class', 'background')
 			.attr('r', ((ring.proportionalSizeEnd * (1 - innerWidth)) + innerWidth) * totalRingSize)
 			.style('fill', ring.fill);
 	}
 	rings.reverse();
 
+	// Add rectangles to hide other quadrants of the circle.
+	rootNode.append('svg:rect')
+		.attr('x', 0)
+		.attr('y', -totalRingSize)
+		.attr('width', totalRingSize)
+		.attr('height', totalRingSize * 2)
+		.style('fill', 'rgba(255, 255, 255, 1)');
+	rootNode.append('svg:rect')
+		.attr('x', -totalRingSize)
+		.attr('y', 0)
+		.attr('width', totalRingSize * 2)
+		.attr('height', totalRingSize)
+		.style('fill', 'rgba(255, 255, 255, 1)');
+
 	for (const lineOrigin of segmentLines) {
-		rootNode.append('line')
+		rootNode.append('svg:line')
 			.attr('x1', lineOrigin.x)
 			.attr('y1', lineOrigin.y)
 			.attr('x2', 0)
@@ -315,25 +329,25 @@ module.exports = function ({
 			.style('stroke', 'rgba(255, 255, 255, 1)');
 	}
 
+	// Nothing goes in the middle ring
+	rootNode.append('svg:circle')
+		.attr('class', 'background')
+		.attr('r', totalRingSize * innerWidth)
+		.style('fill', 'rgba(255, 255, 255, 1)');
+
 
 	for (const ring of rings) {
 		rootNode.append('svg:text')
 			.text(ring.groupLabel || ring.min)
-			.attr('class', 'd3-label bg')
-			.attr('x', '-16px')
-			.attr('y', (((ring.proportionalSizeStart * (1 - innerWidth)) + innerWidth) * -totalRingSize) + 'px');
+			.attr('class', 'd3-label ring-label bg')
+			.attr('x', '45')
+			.attr('y', -10 + (((ring.proportionalSizeStart * (1 - innerWidth)) + innerWidth) * -totalRingSize) + 'px');
 		rootNode.append('svg:text')
 			.text(ring.groupLabel || ring.min)
-			.attr('class', 'd3-label')
-			.attr('x', '-16px')
-			.attr('y', (((ring.proportionalSizeStart * (1 - innerWidth)) + innerWidth) * -totalRingSize) + 'px');
+			.attr('class', 'd3-label ring-label')
+			.attr('x', '45')
+			.attr('y', -10 + (((ring.proportionalSizeStart * (1 - innerWidth)) + innerWidth) * -totalRingSize) + 'px');
 	}
-
-	// Nothing goes in the middle ring
-	rootNode.append('circle')
-		.attr('class', 'background')
-		.attr('r', totalRingSize * innerWidth)
-		.style('fill', 'rgba(255, 255, 255, 1)');
 
 	force.start().alpha(0.05);
 	labelForce.start().alpha(0.05);

--- a/client/js/lib/d3.js
+++ b/client/js/lib/d3.js
@@ -84,6 +84,43 @@ module.exports = function ({
 	}))
 	.filter(l => !l.fixed);
 
+	const labelAnchorNodes = [];
+	const labelAnchorLinks = [];
+	links.forEach((l, i) => {
+		const nodeToAttachTo = nodes[l.source];
+		const x = nodeToAttachTo.x;
+		const y = nodeToAttachTo.y;
+		const weight = 0.1;
+		const text = nodeToAttachTo.name;
+
+		// Has the text
+		const label = {
+			x,
+			y,
+			weight,
+			text,
+			charge: -250,
+			chargeDistance: 90,
+			id: nodeToAttachTo['hidden-graph-item-id'] + '--graph-label'
+		};
+
+		// Pulls the label towards the node
+		const anchorToNode = {
+			x,
+			y,
+			weight,
+			fixed: true
+		};
+		labelAnchorNodes.push(label);
+		labelAnchorNodes.push(anchorToNode);
+		nodeToAttachTo.labelAnchor = anchorToNode;
+		labelAnchorLinks.push({
+			source: 2*i,
+			target: 2*i + 1,
+			distance: 0
+		});
+	});
+
 	// Attract the nodes to the segments
 	nodes.forEach((n,j) => {
 		for(let i=0,l=rings[0].segments.length;i<l;i++) {
@@ -125,16 +162,36 @@ module.exports = function ({
 		.gravity(0)
 		.size([width, height]);
 
+	const labelForce = d3.layout.force()
+		.nodes(labelAnchorNodes)
+		.links(labelAnchorLinks)
+		.charge(n => n.charge || 0)
+		.chargeDistance(n => n.chargeDistance || 10)
+		.gravity(0)
+		.linkStrength(1)
+		.linkDistance(0.1)
+		.size([width, height]);
+
 	force.on('tick', function () {
 
-		// bounce off the walls
 		nodes.forEach(function (d) {
 			if (d.x > width) [d.x, d.px] = [d.px, d.x];
 			if (d.y > height) [d.y, d.py] = [d.py, d.y];
 			d.x = d.x % (width * 4);
 			d.y = d.y % (height * 4);
+
+
+			// Attach the label node to this node
+			if (d.labelAnchor) {
+				d.labelAnchor.x = d.x;
+				d.labelAnchor.y = d.y;
+			}
 		});
 		node.attr('transform', d => `translate(${d.x}, ${d.y})`);
+	});
+
+	labelForce.on('tick', function () {
+		labelNode.attr('transform', d => `translate(${d.x}, ${d.y})`);
 	});
 
 	const node = svg.selectAll('.node')
@@ -144,19 +201,41 @@ module.exports = function ({
 		.attr('class', d => d.rootEl ? 'rootNode' : 'node')
 		.attr('id', n => `${n['hidden-graph-item-id']}--graph-point`);
 
+	const labelNode = svg.selectAll('.label-node')
+		.data(labelAnchorNodes)
+		.enter()
+		.append('svg:g')
+		.attr('id', n => `${n.id}`);
+
+	labelNode
+		.append('svg:text')
+		.text(n => n.text || '')
+		.attr('class', 'd3-label bg')
+		.attr('x', '-10px')
+		.attr('y', '5px');
+
+	labelNode
+		.append('svg:text')
+		.text(n => n.text || '')
+		.attr('class', 'd3-label')
+		.attr('x', '-10px')
+		.attr('y', '5px');
+
 	node.style('display', d => (d.visible === false && d.rootEl !== true) ? 'none' : 'initial');
 
 	function mouseover (d) {
-		renderOnTop.attr('xlink:href', '#' + `${d['hidden-graph-item-id']}--graph-point`);
-		this.parentNode.classList.add('hovering');
+		const labelSelector = '#' + `${d['hidden-graph-item-id']}--graph-label`;
+		renderOnTop.attr('xlink:href', labelSelector);
+		document.querySelector(labelSelector).classList.add('hovering');
 		const row = document.getElementById(d['hidden-graph-item-id']);
 		if (!row) return;
 		row.classList.add('hovering');
 	}
 
 	function mouseout (d) {
+		const labelSelector = '#' + `${d['hidden-graph-item-id']}--graph-label`;
 		renderOnTop.attr('xlink:href', '#');
-		this.parentNode.classList.remove('hovering');
+		document.querySelector(labelSelector).classList.remove('hovering');
 		const row = document.getElementById(d['hidden-graph-item-id']);
 		if (!row) return;
 		row.classList.remove('hovering');
@@ -205,15 +284,15 @@ module.exports = function ({
 		.text(n => n.longDesc);
 
 	node.append('svg:text')
-		.text(n => n.name || '')
-		.attr('class', n => `d3-label bg${n.dot === false ? ' no-dot' : ''}`)
-		.attr('x', n => n.dot !== false ? '-10px' : '0px')
+		.text(n => n.dot === false ? n.name : '')
+		.attr('class', 'd3-label bg no-dot')
+		.attr('x', '-10px')
 		.attr('y', '5px');
 
 	node.append('svg:text')
-		.text(n => n.name || '')
-		.attr('class', n => `d3-label${n.dot === false ? ' no-dot' : ''}`)
-		.attr('x', n => n.dot !== false ? '-10px' : '0px')
+		.text(n => n.dot === false ? n.name : '')
+		.attr('class', 'd3-label no-dot')
+		.attr('x', '-10px')
 		.attr('y', '5px');
 
 	const rootNode = svg.select('.rootNode');
@@ -257,6 +336,7 @@ module.exports = function ({
 		.style('fill', 'rgba(255, 255, 255, 1)');
 
 	force.start().alpha(0.05);
+	labelForce.start().alpha(0.05);
 
 	const renderOnTop = svg
 	.append('svg:g')

--- a/client/js/lib/d3.js
+++ b/client/js/lib/d3.js
@@ -8,7 +8,8 @@
 module.exports = function ({
 	data,
 	size,
-	rings
+	rings,
+	options
 }) {
 
 	const boilDown = document.getElementById('boil-down');
@@ -17,7 +18,7 @@ module.exports = function ({
 	const nodes = data.slice(0);
 	const innerWidth = 0.1;
 	const totalRingSize = height;
-	const chargeDistance = size/4;
+	const chargeDistance = size/2;
 
 	nodes.forEach(n => {
 		n.ring = rings[Math.floor(n.datumValue)];
@@ -27,7 +28,7 @@ module.exports = function ({
 		n.weight = 0.1;
 
 		// Initial boost of repulsion which drives them apart
-		n.charge = -80;
+		n.charge = -100 * (options.nodeRepulsion || 3) * Math.pow((Math.floor(n.datumValue) + 2)/rings.length, 2);
 	});
 
 	nodes.unshift({
@@ -97,7 +98,7 @@ module.exports = function ({
 					target,
 					source: j,
 					distance: 0,
-					linkStrength: 0.03 * Math.pow(1.2, l)
+					linkStrength: 0.01 * (options.nodeAttraction || 3) * Math.pow(1.2, l)
 				});
 				break;
 			}

--- a/client/js/lib/d3.js
+++ b/client/js/lib/d3.js
@@ -8,8 +8,7 @@
 module.exports = function ({
 	data,
 	size,
-	rings,
-	crystallisation,
+	rings
 }) {
 
 	const boilDown = document.getElementById('boil-down');
@@ -28,7 +27,7 @@ module.exports = function ({
 		n.weight = 0.1;
 
 		// Initial boost of repulsion which drives them apart
-		n.charge = -60;
+		n.charge = -80;
 	});
 
 	nodes.unshift({
@@ -98,7 +97,7 @@ module.exports = function ({
 					target,
 					source: j,
 					distance: 0,
-					linkStrength: 0.03 * Math.pow(1.5, l)
+					linkStrength: 0.03 * Math.pow(1.2, l)
 				});
 				break;
 			}
@@ -111,9 +110,9 @@ module.exports = function ({
 
 	const svgNode = document.createElementNS(d3.ns.prefix.svg, 'svg');
 	const svg = d3.select(svgNode)
-		.attr('width', width)
-		.attr('height', height)
-		.attr('viewBox', `0 0 ${width} ${height}`);
+		.attr('width', width + 500)
+		.attr('height', height + 50)
+		.attr('viewBox', `-500 -50 ${width + 500} ${height + 50}`);
 
 	const force = d3.layout.force()
 		.nodes(nodes)
@@ -147,6 +146,7 @@ module.exports = function ({
 	node.style('display', d => (d.visible === false && d.rootEl !== true) ? 'none' : 'initial');
 
 	function mouseover (d) {
+		renderOnTop.attr('xlink:href', '#' + `${d['hidden-graph-item-id']}--graph-point`);
 		this.parentNode.classList.add('hovering');
 		const row = document.getElementById(d['hidden-graph-item-id']);
 		if (!row) return;
@@ -154,6 +154,7 @@ module.exports = function ({
 	}
 
 	function mouseout (d) {
+		renderOnTop.attr('xlink:href', '#');
 		this.parentNode.classList.remove('hovering');
 		const row = document.getElementById(d['hidden-graph-item-id']);
 		if (!row) return;
@@ -255,6 +256,10 @@ module.exports = function ({
 		.style('fill', 'rgba(255, 255, 255, 1)');
 
 	force.start().alpha(0.05);
+
+	const renderOnTop = svg
+	.append('svg:g')
+	.append('svg:use');
 
 	return svgNode;
 };

--- a/client/js/lib/form.js
+++ b/client/js/lib/form.js
@@ -56,6 +56,10 @@ module.exports = function (schema, dataFormat, options) {
 			input = makeSelect(dataFormat, options.sortCol);
 		}
 
+		if (qp === 'segment') {
+			input = makeSelect(dataFormat, options.segment);
+		}
+
 		input.name = qp;
 		label.textContent = `${qp}`;
 		group.appendChild(label);

--- a/client/js/lib/form.js
+++ b/client/js/lib/form.js
@@ -3,6 +3,10 @@
 function makeSelect (items, selected) {
 	const input = document.createElement('select');
 	input.classList.add('o-forms-select');
+	const noSelection = document.createElement('option');
+	noSelection.value = '';
+	noSelection.textContent = 'Default';
+	input.appendChild(noSelection);
 	items.forEach(key => {
 		const o = document.createElement('option');
 		if (key === selected) {
@@ -15,6 +19,7 @@ function makeSelect (items, selected) {
 	return input;
 }
 
+const inputs = [];
 module.exports = function (schema, dataFormat, options) {
 
 	const formLocation = document.getElementById('tech-radar__qp-form');
@@ -30,9 +35,9 @@ module.exports = function (schema, dataFormat, options) {
 		const small = document.createElement('small');
 
 		input.type = 'text';
-		input.placeholder = schema[qp][1].name;
-		label.title = schema[qp][2];
-		small.textContent = schema[qp][2];
+		input.placeholder = schema[qp][1].name + ` (${schema[qp][2]})`;
+		label.title = schema[qp][3];
+		small.textContent = schema[qp][3];
 		input.value = options[schema[qp][0]] || '';
 
 		if (schema[qp][1] === Boolean) {
@@ -66,6 +71,7 @@ module.exports = function (schema, dataFormat, options) {
 		group.appendChild(small);
 		group.appendChild(input);
 		formLocation.appendChild(group);
+		inputs.push(input);
 	}
 	const submit = document.createElement('input');
 	submit.type = 'submit';
@@ -77,4 +83,9 @@ module.exports = function (schema, dataFormat, options) {
 	formLocation.appendChild(hiddenSubmit);
 	formLocation.parentNode.appendChild(submit);
 	formWrapper.style.height = formLocation.clientHeight + submit.clientHeight + label.clientHeight + 16 + 'px';
+
+	formLocation.addEventListener('submit', function () {
+		inputs.forEach(el => el.disabled = !el.value);
+		setTimeout(() => inputs.forEach(el => el.disabled = false), 0);
+	});
 };

--- a/client/js/main.js
+++ b/client/js/main.js
@@ -7,7 +7,7 @@ const qpSchema = {
 	sortcol: ['sortCol', String, 'phase', 'Which column to sort by'],
 	title: ['title', String, '', 'Title to display'],
 	showcol: ['showCol', Array, [], 'Comma seperated list of columns to show'],
-	dashboard: ['dashboard', Boolean, true, 'Whether to display these settings.'],
+	dashboard: ['dashboard', Boolean, false, 'Whether to display these settings.'],
 	showtable: ['showTable', Boolean, true, 'Whether to display the data table'],
 	sortcolorder: ['sortColOrder', Array, [], 'Comma seperated list, order to sort the rings'],
 	segment: ['segment', String, '', 'Column to use to segment the data, defaults to the source spreadsheet.'],
@@ -125,7 +125,7 @@ function getDocsFromBertha (docs, republish = false) {
 			let i = 0;
 			for (const datum of json) {
 				datum['hidden-graph-item-source'] = `${doc.UID}/${doc.sheet}`;
-				datum['hidden-graph-item-id'] = (`${datum.name}---${doc.UID}---${doc.sheet}---${i++}`).replace(/[^a-z_\-0-9]/ig, '_'); 
+				datum['hidden-graph-item-id'] = (`${datum.name}---${doc.UID}---${doc.sheet}---${i++}`).replace(/[^a-z_\-0-9]/ig, '_');
 			}
 
 			// override options

--- a/client/js/main.js
+++ b/client/js/main.js
@@ -15,6 +15,8 @@ const qpSchema = {
 	proportionalrings: ['useProportionalRings', Boolean, 'Whether to scale rings according to number of items.'],
 	sorttype: ['sortType', String, '"alphabetical" or "numerical" (without quotes)'],
 	crystallisation: ['crystallisation', String, 'Make this row the focus of attention.'],
+	noderepulsion: ['nodeRepulsion', Number, 'How strongly the nodes repel each other (default, 3)'],
+	nodeattraction: ['nodeAttraction', Number, 'How strongly the nodes are pulled to the center of the segment (default, 3)'],
 };
 
 const options = {};
@@ -454,7 +456,7 @@ function generateGraphs (inData) {
 		data,
 		size: Math.min(svgTarget.clientWidth, document.body.clientHeight - header.clientHeight - footer.clientHeight),
 		rings: generateChartRings(data, labels),
-		crystallisation : options.crystallisation
+		options
 	});
 	svgTarget.appendChild(svg);
 

--- a/client/js/main.js
+++ b/client/js/main.js
@@ -11,7 +11,7 @@ const qpSchema = {
 	showtable: ['showTable', Boolean, true, 'Whether to display the data table'],
 	sortcolorder: ['sortColOrder', Array, [], 'Comma seperated list, order to sort the rings'],
 	segment: ['segment', String, '', 'Column to use to segment the data, defaults to the source spreadsheet.'],
-	ringcolor: ['ringColor', String, '', 'Colour to use for the ring (rainbow makes it multicolour)'],
+	ringcolor: ['ringColor', String, '', 'Colour to use for the ring (try rainbow to make multicolour)'],
 	proportionalrings: ['useProportionalRings', Boolean, false, 'Whether to scale rings according to number of items.'],
 	sorttype: ['sortType', String, '', '"alphabetical" or "numerical" (without quotes)'],
 	crystallisation: ['crystallisation', String, '', 'Make this row the focus of attention.'],

--- a/client/scss/main.scss
+++ b/client/scss/main.scss
@@ -79,15 +79,15 @@ div, form {
 svg {
 	max-width: 100%;
 	height: auto;
+	font-size: 1.3em;
+	font-family: MetricWeb, helvetica, sans;
+	font-weight: bold;
 
 	.d3-label {
 		fill: #333;
 		fill-opacity: 1;
 		z-index: 10;
-		font-size: 14pt;
-		font-weight: bold;
 		pointer-events: none;
-		font-family: MetricWeb, helvetica, sans;
 		transition: transform 0.2s ease;
 		text-anchor: end;
 
@@ -104,6 +104,14 @@ svg {
 			fill: black;
 			text-decoration: underline;
 			font-size: 18pt;
+		}
+	}
+
+	// Hide it do that the use label is shown instead
+	.hovering {
+		.d3-label {
+			font-weight: bold;
+			font-size: 130%;
 		}
 	}
 
@@ -125,17 +133,6 @@ svg {
 
 use {
 	pointer-events: none;
-}
-
-g.node {
-	&.hovering {
-		z-index: 10;
-		font-weight: bold;
-
-		.d3-label {
-			font-size: 150%;
-		}
-	}
 }
 
 .details {

--- a/client/scss/main.scss
+++ b/client/scss/main.scss
@@ -42,6 +42,19 @@ div, form {
 	}
 }
 
+#tech-radar__graph-target {
+	flex-grow: 1;
+	margin-left: -250px;
+	min-width: 500px;
+	text-align: right;
+}
+
+#tech-radar__display {
+	display: flex;
+	flex-direction: row-reverse;
+	justify-content: flex-end;
+}
+
 .filter-table {
 
 	white-space: nowrap;
@@ -110,11 +123,18 @@ svg {
 	}
 }
 
-.hovering {
-	font-weight: bold;
+use {
+	pointer-events: none;
+}
 
-	.d3-label {
-		font-size: 150%;
+g.node {
+	&.hovering {
+		z-index: 10;
+		font-weight: bold;
+
+		.d3-label {
+			font-size: 150%;
+		}
 	}
 }
 

--- a/client/scss/main.scss
+++ b/client/scss/main.scss
@@ -84,7 +84,7 @@ svg {
 	font-weight: bold;
 
 	.d3-label {
-		fill: #333;
+		fill: black;
 		fill-opacity: 1;
 		z-index: 10;
 		pointer-events: none;
@@ -100,7 +100,17 @@ svg {
 			stroke-alignment: outer;
 		}
 
-		&.no-dot {
+		&.ring-label {
+			fill: white;
+			font-size: 18pt;
+
+			&.bg{
+				stroke: black;
+				stroke-width: 5px;
+			}
+		}
+
+		&.segment-label {
 			fill: black;
 			text-decoration: underline;
 			font-size: 18pt;
@@ -124,7 +134,7 @@ svg {
 		stroke-width: 2px;
 		stroke: black;
 
-		&.no-dot {
+		&.segment-label {
 			display: none;
 			font-size: 16pt;
 		}


### PR DESCRIPTION
shows all the labels tweaked repulsion and scattering, falls back to using sheet name as the title if one is not set.
You can also segment by the title and the title will be shown on the segments.
if you mouse over an element it will be brought to the front
(z-index doesn't work in svg but found a cool work around)

Allow user to choose repulsion
decouple labels
Validate items to remove default values from query params
